### PR TITLE
fix: rely on defaults excludes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,8 +32,3 @@ plugins:
   - jekyll-feed
   - jekyll-seo-tag
   - jekyll-include-cache
-exclude:
-  - [vendor]
-  - vendor
-  - Gemfile
-  - Gemfile.lock


### PR DESCRIPTION
Those files are already excluded by default (see https://jekyllrb.com/docs/configuration/default/)